### PR TITLE
Two bugs fixed

### DIFF
--- a/getIpcPath.js
+++ b/getIpcPath.js
@@ -4,17 +4,29 @@ Gets the right IPC path
 @module getIpcPath
 */
 
+var fs = require("fs");
+
 module.exports = function() {
     var p = require('path');
     var path = process.env.HOME;
 
-    if(process.platform === 'darwin')
-        path += '/Library/Ethereum/geth.ipc';
+    var macDefaultDir = "/Library/Ethereum/geth.ipc";
+    var linuxDefaultDir = "/.ethereum/geth.ipc";
+
+    if(process.platform === 'darwin') {
+        if(fs.existsSync(path + macDefaultDir))
+          path += macDefaultDir;
+        else
+          if(fs.existsSync(path + linuxDefaultDir))
+            path += linuxDefaultDir;
+          else
+            path += macDefaultDir;
+    }
 
     if(process.platform === 'freebsd' ||
        process.platform === 'linux' ||
        process.platform === 'sunos')
-        path += '/.ethereum/geth.ipc';
+        path += linuxDefaultDir;
 
     if(process.platform === 'win32')
         path = '\\\\.\\pipe\\geth.ipc';

--- a/main.js
+++ b/main.js
@@ -53,7 +53,11 @@ web3.eth.getBlockNumber(function(err, number)
 		else
 		{
 			console.log("Entering interactive mode.");
-			repl.start();
+			repl.start({
+				prompt: "> ",
+				input: process.stdin,
+				output: process.stdout
+			});
 		}
 	}
 });


### PR DESCRIPTION
- `getIpcPath` on MacOSX can sometimes be the same as in Linux, so I add check: check default MacOSX path, then check Linux default path, and if no .ipc file found, using MacOSX default path.

- `repl(...)` options is mandatory now, so I provided options to repl.
