### PR TITLE
fix admin_addPeer formatter

### DIFF
--- a/web3Admin.js
+++ b/web3Admin.js
@@ -10,7 +10,7 @@ module.exports = {
                     name: 'addPeer',
                     call: 'admin_addPeer',
                     params: 1,
-                    inputFormatter: [web3._extend.utils.fromDecimal],
+                    inputFormatter: [web3._extend.utils.formatInputString],
                     outputFormatter: web3._extend.formatters.formatOutputBool
                 }),
                 new web3._extend.Method({


### PR DESCRIPTION
Fix for this issue
```
web3.admin.addPeer("enode://d3a7737d77f323659b8f9facdb94291973af9198ec18bfbc4f5dd1e4cb4fc041193e630c75ea08a34934feec849e6dbd345a24f826cc4420d86012d534d2c303@127.0.0.1:30305", function(err,res) {console.log(res)})
BigNumber Error: new BigNumber() not a number: enode://d3a7737d77f323659b8f9facdb94291973af9198ec18bfbc4f5dd1e4cb4fc041193e630c75ea08a34934feec849e6dbd345a24f826cc4420d86012d534d2c303@127.0.0.1:30305
    at raise (/home/wins/Ethereum/ethereum-console/node_modules/web3/node_modules/bignumber.js/bignumber.js:1177:25)
```